### PR TITLE
Add python a system dependencies to package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -7,11 +7,19 @@
     <license>BSD</license>
     <buildtool_depend>catkin</buildtool_depend>
     <depend>java</depend>
-    <depend>pcl_ros</depend>    
-    <depend>pcl_plugin</depend>    
+    <depend>pcl_ros</depend>
+    <depend>pcl_plugin</depend>
     <depend>ctk_python_console</depend>
     <depend>qt_property_browser</depend>
     <depend>python_qt</depend>
     <depend>digiforest_drs</depend>
+    <depend>python-utm-pip</depend>
+    <depend>pymap3d-pip</depend>
+    <depend>python3-lxml</depend>
+    <depend>cython3</depend>
+    <depend>libpcl-all-dev</depend>
+    <depend>libqwt-qt5-dev</depend>
+    <depend>qtbase5-private-dev</depend>
+    <depend>qtmultimedia5-dev</depend>
 </package>
 


### PR DESCRIPTION
This PR adds dependencies currently installed "by hand" to the `package.xml` to facilitate automatic installation through `rosdep`.
